### PR TITLE
feat: Implemented selector/verifier pattern for refresh tokens and improve JWT validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Database
 DATABASE_URL=postgres connection string here
 
+# Authentication
+BCRYPT_COST=10
+
 # Logger
 LOG_LEVEL= # info | fatal | error | warn | debug | trace | silent
 

--- a/drizzle/0009_add_selector_to_refresh_tokens.sql
+++ b/drizzle/0009_add_selector_to_refresh_tokens.sql
@@ -1,0 +1,16 @@
+-- Add selector column for O(1) refresh token lookups
+-- This prevents O(N) bcrypt scans by using an indexable selector + hashed verifier pattern
+
+ALTER TABLE "refresh_tokens" ADD COLUMN "selector" varchar(12) NOT NULL DEFAULT '';
+
+-- Remove the unique constraint on token_hash since we'll have multiple tokens with different selectors
+ALTER TABLE "refresh_tokens" DROP CONSTRAINT "refresh_tokens_token_hash_unique";
+
+-- Add unique constraint on selector for fast lookups
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_selector_unique" UNIQUE("selector");
+
+-- Add index on expires_at for efficient cleanup queries
+CREATE INDEX "refresh_tokens_expires_at_idx" ON "refresh_tokens" ("expires_at");
+
+-- Remove the default empty string constraint after adding the column
+ALTER TABLE "refresh_tokens" ALTER COLUMN "selector" DROP DEFAULT;

--- a/drizzle/0009_complex_junta.sql
+++ b/drizzle/0009_complex_junta.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "refresh_tokens" DROP CONSTRAINT "refresh_tokens_token_hash_unique";--> statement-breakpoint
+ALTER TABLE "refresh_tokens" DROP CONSTRAINT "refresh_tokens_expires_at_unique";--> statement-breakpoint
+ALTER TABLE "refresh_tokens" ADD COLUMN "selector" varchar(12) NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "refresh_tokens_selector_idx" ON "refresh_tokens" USING btree ("selector");--> statement-breakpoint
+CREATE INDEX "refresh_tokens_expires_at_idx" ON "refresh_tokens" USING btree ("expires_at");--> statement-breakpoint
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_selector_unique" UNIQUE("selector");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1051 @@
+{
+  "id": "d485ec68-385f-4fdf-8659-dbb558e2bb5e",
+  "prevId": "3da8be10-c325-4222-92fd-fa7ed11f4763",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admins": {
+      "name": "admins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admins_user_id_users_id_fk": {
+          "name": "admins_user_id_users_id_fk",
+          "tableFrom": "admins",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lab_activity_log": {
+      "name": "lab_activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "laboratory_id": {
+          "name": "laboratory_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seating_id": {
+          "name": "seating_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_in": {
+          "name": "time_in",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_out": {
+          "name": "time_out",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lab_activity_log_laboratory_id_laboratory_id_fk": {
+          "name": "lab_activity_log_laboratory_id_laboratory_id_fk",
+          "tableFrom": "lab_activity_log",
+          "tableTo": "laboratory",
+          "columnsFrom": [
+            "laboratory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_activity_log_schedule_id_schedule_id_fk": {
+          "name": "lab_activity_log_schedule_id_schedule_id_fk",
+          "tableFrom": "lab_activity_log",
+          "tableTo": "schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "lab_activity_log_seating_id_seating_history_id_fk": {
+          "name": "lab_activity_log_seating_id_seating_history_id_fk",
+          "tableFrom": "lab_activity_log",
+          "tableTo": "seating_history",
+          "columnsFrom": [
+            "seating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.laboratory": {
+      "name": "laboratory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "time_in": {
+          "name": "time_in",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_out": {
+          "name": "time_out",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "selector": {
+          "name": "selector",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_tokens_selector_idx": {
+          "name": "refresh_tokens_selector_idx",
+          "columns": [
+            {
+              "expression": "selector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_tokens_expires_at_idx": {
+          "name": "refresh_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_selector_unique": {
+          "name": "refresh_tokens_selector_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "selector"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedule": {
+      "name": "schedule",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "laboratory_id": {
+          "name": "laboratory_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_id": {
+          "name": "subject_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'scheduled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "schedule_laboratory_id_laboratory_id_fk": {
+          "name": "schedule_laboratory_id_laboratory_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "laboratory",
+          "columnsFrom": [
+            "laboratory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_teacher_id_teachers_id_fk": {
+          "name": "schedule_teacher_id_teachers_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "teachers",
+          "columnsFrom": [
+            "teacher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "schedule_subject_id_subjects_id_fk": {
+          "name": "schedule_subject_id_subjects_id_fk",
+          "tableFrom": "schedule",
+          "tableTo": "subjects",
+          "columnsFrom": [
+            "subject_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seating_history": {
+      "name": "seating_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "laboratory_id": {
+          "name": "laboratory_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seating_id": {
+          "name": "seating_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monitor": {
+          "name": "monitor",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mouse": {
+          "name": "mouse",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyboard": {
+          "name": "keyboard",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cables": {
+          "name": "cables",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seating_history_laboratory_id_laboratory_id_fk": {
+          "name": "seating_history_laboratory_id_laboratory_id_fk",
+          "tableFrom": "seating_history",
+          "tableTo": "laboratory",
+          "columnsFrom": [
+            "laboratory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "seating_history_student_id_students_id_fk": {
+          "name": "seating_history_student_id_students_id_fk",
+          "tableFrom": "seating_history",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "seating_history_seating_id_seating_plan_id_fk": {
+          "name": "seating_history_seating_id_seating_plan_id_fk",
+          "tableFrom": "seating_history",
+          "tableTo": "seating_plan",
+          "columnsFrom": [
+            "seating_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.seating_plan": {
+      "name": "seating_plan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "laboratory_id": {
+          "name": "laboratory_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_number": {
+          "name": "seat_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "monitor_status": {
+          "name": "monitor_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mouse_status": {
+          "name": "mouse_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyboard_status": {
+          "name": "keyboard_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cables_status": {
+          "name": "cables_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "seating_plan_laboratory_id_laboratory_id_fk": {
+          "name": "seating_plan_laboratory_id_laboratory_id_fk",
+          "tableFrom": "seating_plan",
+          "tableTo": "laboratory",
+          "columnsFrom": [
+            "laboratory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "seating_plan_schedule_id_schedule_id_fk": {
+          "name": "seating_plan_schedule_id_schedule_id_fk",
+          "tableFrom": "seating_plan",
+          "tableTo": "schedule",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "seating_plan_student_id_students_id_fk": {
+          "name": "seating_plan_student_id_students_id_fk",
+          "tableFrom": "seating_plan",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.students": {
+      "name": "students",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section": {
+          "name": "section",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "course": {
+          "name": "course",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "students_student_id_unique": {
+          "name": "students_student_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "student_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subjects": {
+      "name": "subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_name": {
+          "name": "subject_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject_code": {
+          "name": "subject_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teachers": {
+      "name": "teachers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance": {
+          "name": "attendance",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'present'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teachers_user_id_users_id_fk": {
+          "name": "teachers_user_id_users_id_fk",
+          "tableFrom": "teachers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.technical_staff": {
+      "name": "technical_staff",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstname": {
+          "name": "firstname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastname": {
+          "name": "lastname",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "technical_staff_user_id_users_id_fk": {
+          "name": "technical_staff_user_id_users_id_fk",
+          "tableFrom": "technical_staff",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(12)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_deleted": {
+          "name": "is_deleted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1754483864532,
       "tag": "0008_known_impossible_man",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1757084486431,
+      "tag": "0009_complex_junta",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,6 @@
 import { z } from '@hono/zod-openapi'
 import { relations } from 'drizzle-orm'
-import { boolean, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core'
+import { boolean, index, pgTable, timestamp, uniqueIndex, varchar } from 'drizzle-orm/pg-core'
 import { createSchemaFactory } from 'drizzle-zod'
 import { nanoid } from 'nanoid'
 
@@ -477,9 +477,11 @@ export const refreshTokens = pgTable('refresh_tokens', {
   user_id: varchar('user_id', { length: 12 })
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
-  token_hash: varchar('token_hash', { length: 255 })
+  selector: varchar('selector', { length: 12 })
     .notNull()
-    .unique(),
+    .unique(), // Unique constraint on selector for O(1) lookups
+  token_hash: varchar('token_hash', { length: 255 })
+    .notNull(), // Removed unique constraint - hash of verifier part only
   expires_at: timestamp('expires_at', { mode: 'date' })
     .notNull(),
   created_at: timestamp({ mode: 'date' })
@@ -489,7 +491,10 @@ export const refreshTokens = pgTable('refresh_tokens', {
     .notNull()
     .defaultNow()
     .$onUpdate(() => new Date()),
-})
+}, (table) => ({
+  selectorIdx: uniqueIndex('refresh_tokens_selector_idx').on(table.selector),
+  expiresAtIdx: index('refresh_tokens_expires_at_idx').on(table.expires_at),
+}))
 
 export const refreshTokenSelectSchema = createSelectSchema(refreshTokens)
 export const refreshTokenInsertSchema = createInsertSchema(refreshTokens)

--- a/src/handlers/auth/get-current-user.handler.ts
+++ b/src/handlers/auth/get-current-user.handler.ts
@@ -3,9 +3,13 @@
  * Response follows { message, data } format.
  */
 
+import type { z } from '@hono/zod-openapi'
 import type { AppRouteHandler } from '@/lib/types/app-types'
+import type { jwtPayloadSchema } from '@/lib/zod-schemas'
 import type { GetCurrentUserRoute } from '@/routes/auth/auth.routes'
 import * as httpStatusCodes from '@/openapi/http-status-codes'
+
+type JWTPayload = z.infer<typeof jwtPayloadSchema>
 
 /**
  * Handles the request to get the current user's information from the JWT payload.
@@ -18,7 +22,7 @@ import * as httpStatusCodes from '@/openapi/http-status-codes'
 export const GetCurrentUserHandler: AppRouteHandler<GetCurrentUserRoute> = async (c) => {
   try {
     // Retrieve the JWT payload attached by the authentication middleware
-    const payload = c.get('jwtPayload')
+    const payload = c.get('jwtPayload') as JWTPayload
     const { sub, role } = payload
 
     // Return the essential user information from the token

--- a/src/lib/zod-schemas/auth.schema.ts
+++ b/src/lib/zod-schemas/auth.schema.ts
@@ -10,6 +10,12 @@ export const meDataSchema = z.object({
   role: z.string(),
 })
 
+export const jwtPayloadSchema = z.object({
+  sub: z.string(),
+  role: z.string(),
+  exp: z.number(),
+})
+
 export const loginResponseSchema = z.object({
   message: z.string(),
   data: z.object({

--- a/src/lib/zod-schemas/index.ts
+++ b/src/lib/zod-schemas/index.ts
@@ -2,6 +2,7 @@
 export {
   basicMessageResponseSchema,
   errorResponseSchema,
+  jwtPayloadSchema,
   loginBodySchema,
   loginResponseSchema,
   meDataSchema,

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,14 +1,12 @@
+import type { z } from '@hono/zod-openapi'
 import type { AppBindings } from '@/lib/types/app-types'
 import { getCookie } from 'hono/cookie'
 import { createMiddleware } from 'hono/factory'
 import { verify } from 'hono/jwt'
+import { jwtPayloadSchema } from '@/lib/zod-schemas'
 import * as httpStatusCodes from '@/openapi/http-status-codes'
 
-interface JWTPayload {
-  sub: string
-  role: string
-  exp: number
-}
+export type JWTPayload = z.infer<typeof jwtPayloadSchema>
 
 /**
  * Middleware for authenticating requests using a JWT token from a cookie.
@@ -33,8 +31,9 @@ export const authMiddleware = createMiddleware<AppBindings>(async (c, next) => {
 
   try {
     // Verify the token and set the payload in the context
-    const payload = await verify(token, c.env.JWT_SECRET) as unknown as JWTPayload
-    c.set('jwtPayload', payload)
+    const payload = await verify(token, c.env.JWT_SECRET)
+    const validatedPayload = jwtPayloadSchema.parse(payload)
+    c.set('jwtPayload', validatedPayload)
   }
   catch (error) {
     // If the token is invalid, return an unauthorized response
@@ -59,6 +58,19 @@ export function requireRole(allowedRoles: string[]) {
       return c.json(
         {
           message: 'Unauthorized: Authentication required',
+        },
+        httpStatusCodes.UNAUTHORIZED,
+      )
+    }
+
+    // Validate the payload structure
+    try {
+      jwtPayloadSchema.parse(payload)
+    } catch (error) {
+      c.var.logger.warn('Role check failed: Invalid JWT payload structure', { error: (error as Error).message })
+      return c.json(
+        {
+          message: 'Unauthorized: Invalid token structure',
         },
         httpStatusCodes.UNAUTHORIZED,
       )

--- a/src/middleware/env.ts
+++ b/src/middleware/env.ts
@@ -5,6 +5,7 @@ const EnvSchema = z.object({
   NODE_ENV: z.string(),
   DATABASE_URL: z.string(),
   JWT_SECRET: z.string(),
+  BCRYPT_COST: z.string().default('10'),
 })
 
 export type Environment = z.infer<typeof EnvSchema>

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -106,13 +106,20 @@ export class AuthService {
       exp: Math.floor(Date.now() / 1000) + (15 * 60), // 15 minutes
     }, this.c.env.JWT_SECRET)
 
-    const refreshToken = nanoid(48)
-    const refreshTokenHash = await bcrypt.hash(refreshToken, 10)
+    // Generate selector/verifier pattern for secure O(1) lookups
+    const selector = nanoid(12) // Public, indexable part
+    const verifier = nanoid(48) // Secret part
+    const refreshToken = `${selector}.${verifier}` // Client receives this
+
+    // Hash only the verifier part
+    const bcryptCost = Number.parseInt(this.c.env.BCRYPT_COST || '10')
+    const refreshTokenHash = await bcrypt.hash(verifier, bcryptCost)
     const refreshTokenExpiresAt = new Date(Date.now() + (7 * 24 * 60 * 60 * 1000)) // 7 days
 
     await this.db.insert(refreshTokens).values({
       user_id: user.id,
-      token_hash: refreshTokenHash,
+      selector, // Store the public selector for indexable lookups
+      token_hash: refreshTokenHash, // Store hash of the secret verifier
       expires_at: refreshTokenExpiresAt,
     })
 
@@ -159,50 +166,59 @@ export class AuthService {
    * ```
    */
   async issueNewAccessToken(refreshToken: string): Promise<string> {
-    const now = new Date();
-    
-    // Clean up expired tokens first
-    await this.db.delete(refreshTokens).where(lt(refreshTokens.expires_at, now));
-    
-    // Get potentially valid refresh tokens (not expired)
-    const sessions = await this.db.query.refreshTokens.findMany({
-      where: gte(refreshTokens.expires_at, now),
-      with: { user: true },
-    });
+    const now = new Date()
 
-    // Find the session by comparing the hashed token
-    let validSession = null;
-    for (const session of sessions) {
-      const isValidToken = await bcrypt.compare(refreshToken, session.token_hash);
-      if (isValidToken) {
-        validSession = session;
-        break;
-      }
+    // Will convert this to a bg process / j*b in the future
+    await this.db.delete(refreshTokens).where(lt(refreshTokens.expires_at, now))
+
+    // Split the refresh token into selector and verifier
+    const parts = refreshToken.split('.')
+    if (parts.length !== 2) {
+      throw new Error('Invalid refresh token format')
     }
+    const [selector, verifier] = parts
+    if (!selector || !verifier) {
+      throw new Error('Invalid refresh token')
+    }
+
+    // Find token by selector and check expiry in one indexed query (O(1) lookup)
+    const validSession = await this.db.query.refreshTokens.findFirst({
+      where: and(
+        eq(refreshTokens.selector, selector),
+        gte(refreshTokens.expires_at, now),
+      ),
+      with: { user: true },
+    })
 
     if (!validSession) {
-      throw new Error('Invalid refresh token');
+      throw new Error('Invalid refresh token') // Not found or expired
     }
 
-    const user = validSession.user;
+    // Verify the secret part (verifier) with a single bcrypt compare
+    const isValidToken = await bcrypt.compare(verifier, validSession.token_hash)
+    if (!isValidToken) {
+      throw new Error('Invalid refresh token') // Hash mismatch
+    }
+
+    const user = validSession.user
     if (!user) {
-      await this.db.delete(refreshTokens).where(eq(refreshTokens.id, validSession.id));
-      throw new Error('User for this session not found');
+      await this.db.delete(refreshTokens).where(eq(refreshTokens.id, validSession.id))
+      throw new Error('User for this session not found')
     }
 
     // Check if user is soft deleted
     if (user.is_deleted) {
-      await this.db.delete(refreshTokens).where(eq(refreshTokens.id, validSession.id));
-      throw new Error('User account is deactivated');
+      await this.db.delete(refreshTokens).where(eq(refreshTokens.id, validSession.id))
+      throw new Error('User account is deactivated')
     }
 
     const newAccessToken = await sign({
       sub: user.id,
       role: user.user_type,
       exp: Math.floor(Date.now() / 1000) + (15 * 60), // 15 minutes
-    }, this.c.env.JWT_SECRET);
-    
-    return newAccessToken;
+    }, this.c.env.JWT_SECRET)
+
+    return newAccessToken
   }
 
   /**
@@ -234,22 +250,31 @@ export class AuthService {
    *       making it safe to call during cleanup operations
    */
   async invalidateRefreshSession(refreshToken: string) {
-    // Clean up expired tokens first
-    const now = new Date();
-    await this.db.delete(refreshTokens).where(lt(refreshTokens.expires_at, now));
-    
-    // Get potentially valid refresh tokens (not expired)
-    const sessions = await this.db.query.refreshTokens.findMany({
-      where: gte(refreshTokens.expires_at, now),
-    });
+    const now = new Date()
+    // will convert this later if it causes issues
+    await this.db.delete(refreshTokens).where(lt(refreshTokens.expires_at, now))
 
-    // Find the session by comparing the hashed token
-    for (const session of sessions) {
-      const isValidToken = await bcrypt.compare(refreshToken, session.token_hash);
-      if (isValidToken) {
-        await this.db.delete(refreshTokens).where(eq(refreshTokens.id, session.id));
-        break;
-      }
+    // Split the refresh token into selector and verifier
+    const parts = refreshToken.split('.')
+    if (parts.length !== 2)
+      return
+
+    const [selector, verifier] = parts
+    if (!selector || !verifier)
+      return
+
+    // Find token by selector and check expiry (O(1) lookup)
+    const session = await this.db.query.refreshTokens.findFirst({
+      where: and(
+        eq(refreshTokens.selector, selector),
+        gte(refreshTokens.expires_at, now),
+      ),
+    })
+
+    // Verify the token and delete if valid
+    if (session && await bcrypt.compare(verifier, session.token_hash)) {
+      await this.db.delete(refreshTokens).where(eq(refreshTokens.id, session.id))
     }
+    // If not found, expired, or hash mismatch, do nothing (no-op)
   }
 }


### PR DESCRIPTION
- implemented secure selector/verifier pattern for refresh tokens storage
- split refresh tokens into 'selector.verifier' format for enhanced security
- added a selector column to refresh_tokens table for O(1) lookups
- removed unique constraint on token_hash and added it to the selector field instead
- added indexes on selector and expires_at fields for efficient queries
- only hash the verifier part for improved security
- updated authservice to use the new selector/verifier pattern
- added jwtPayload zod schema for proper jwt payload validation
- replaced payload validation in auth middleware and role check
- replaced jwtPayload interface with Zod-inferred type for better type safety
- refreshj tokens are now split into two parts and only one of which is hashed
- ser tapos na po