### PR TITLE
feat: add new teacher endpoint (GET /teachers/laboratories)

### DIFF
--- a/src/handlers/teachers/get-teacher-laboratories.handler.ts
+++ b/src/handlers/teachers/get-teacher-laboratories.handler.ts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Get Teacher Laboratories handler - retrieves all laboratories with vacancy status
+ */
+
+import type { AppRouteHandler } from '@/lib/types/app-types'
+import type { GetTeacherLaboratories } from '@/routes/teachers/teachers.routes'
+import * as httpStatusCodes from '@/openapi/http-status-codes'
+import { TeacherService } from '@/services/TeacherService'
+
+/**
+ * Retrieves all laboratories with their current status
+ */
+export const GetTeacherLaboratoriesHandler: AppRouteHandler<GetTeacherLaboratories> = async (c) => {
+  try {
+    const teacherService = new TeacherService(c)
+    const laboratories = await teacherService.getLaboratoriesWithCurrentStatus()
+
+    return c.json(
+      {
+        message: 'Laboratories with current status retrieved successfully',
+        data: laboratories,
+      },
+      httpStatusCodes.OK,
+    )
+  }
+  catch (err) {
+    c.var.logger.error('Failed to retrieve laboratories', {
+      error: (err as Error).message,
+      timestamp: new Date().toISOString(),
+    })
+
+    return c.json(
+      {
+        message: 'Internal Server Error',
+        errors: (err as Error).message,
+      },
+      httpStatusCodes.INTERNAL_SERVER_ERROR,
+    )
+  }
+}

--- a/src/routes/teachers/teachers.index.ts
+++ b/src/routes/teachers/teachers.index.ts
@@ -1,9 +1,10 @@
 import * as dashboardHandlers from '@/handlers/teachers/get-teacher-dashboard.handler'
+import * as laboratoriesHandlers from '@/handlers/teachers/get-teacher-laboratories.handler'
 import * as teachersHandlers from '@/handlers/teachers/get-teachers.handler'
 
 import { createRouter } from '@/lib/create-app'
 import { authMiddleware, requireRole } from '@/middleware/auth'
-import { getTeacherDashboardRoute, getTeachersRoute } from '@/routes/teachers/teachers.routes'
+import { getTeacherDashboardRoute, getTeacherLaboratoriesRoute, getTeachersRoute } from '@/routes/teachers/teachers.routes'
 
 const router = createRouter()
 
@@ -13,5 +14,6 @@ router.use('/teachers/*', authMiddleware, requireRole(['teacher', 'admin']))
 
 router.openapi(getTeachersRoute, teachersHandlers.GetTeachersHandler)
 router.openapi(getTeacherDashboardRoute, dashboardHandlers.GetTeacherDashboardHandler)
+router.openapi(getTeacherLaboratoriesRoute, laboratoriesHandlers.GetTeacherLaboratoriesHandler)
 
 export default router

--- a/src/routes/teachers/teachers.routes.ts
+++ b/src/routes/teachers/teachers.routes.ts
@@ -18,14 +18,10 @@ export const getTeacherDashboardRoute = createRoute({
     query: teacherDashboardQuerySchema,
   },
   responses: {
-    [httpStatusCodes.OK]: {
-      content: {
-        'application/json': { // TODO: Refactor this to follow the standard convention by directly using jsoncContent instead of this
-          schema: teacherDashboardResponseSchema,
-        },
-      },
-      description: 'Teacher dashboard data retrieved successfully',
-    },
+    [httpStatusCodes.OK]: jsonContent(
+      teacherDashboardResponseSchema,
+      'Teacher dashboard data retrieved successfully',
+    ),
     [httpStatusCodes.BAD_REQUEST]: jsonContent(
       z.object({
         message: z.string(),
@@ -76,5 +72,45 @@ export const getTeachersRoute = createRoute({
   },
 })
 
+export const getTeacherLaboratoriesRoute = createRoute({
+  tags: ['Teachers'],
+  method: 'get',
+  path: '/teachers/laboratories',
+  responses: {
+    [httpStatusCodes.OK]: jsonContent(
+      z.object({
+        message: z.string(),
+        data: z.array(
+          z.object({
+            id: z.string(),
+            name: z.string(),
+            status: z.boolean(),
+            vacancy_status: z.enum(['available', 'occupied', 'maintenance']),
+            current_schedule: z.object({
+              id: z.string(),
+              section: z.string(),
+              start_time: z.string(),
+              end_time: z.string(),
+              subject_name: z.string(),
+              teacher_name: z.string(),
+            }).nullable(),
+            created_at: z.string(),
+            updated_at: z.string(),
+          }),
+        ),
+      }),
+      'Laboratories with current status retrieved successfully',
+    ),
+    [httpStatusCodes.INTERNAL_SERVER_ERROR]: jsonContent(
+      z.object({
+        message: z.string(),
+        errors: z.any(),
+      }),
+      'Internal Server Error',
+    ),
+  },
+})
+
 export type GetTeachers = typeof getTeachersRoute
 export type GetTeacherDashboard = typeof getTeacherDashboardRoute
+export type GetTeacherLaboratories = typeof getTeacherLaboratoriesRoute

--- a/src/services/TeacherService.ts
+++ b/src/services/TeacherService.ts
@@ -260,4 +260,97 @@ export class TeacherService {
       throw error
     }
   }
+
+  /**
+   * Retrieves all laboratories with their current status
+   * Determines if a lab is available, occupied, or under maintenance
+   */
+  async getLaboratoriesWithCurrentStatus() {
+    try {
+      const now = new Date()
+      // Get all laboratories with their current schedules (if any)
+      const laboratoriesWithSchedules = await this.db
+        .select({
+          id: laboratory.id,
+          name: laboratory.name,
+          status: laboratory.status,
+          created_at: laboratory.created_at,
+          updated_at: laboratory.updated_at,
+          // Schedule information (if currently active)
+          scheduleId: schedule.id,
+          section: schedule.section,
+          startTime: schedule.start_time,
+          endTime: schedule.end_time,
+          scheduleStatus: schedule.status,
+          // Subject and teacher information
+          subjectName: subjects.subject_name,
+          teacherFirstname: teachers.firstname,
+          teacherLastname: teachers.lastname,
+        })
+        .from(laboratory)
+        .leftJoin(
+          schedule,
+          and(
+            eq(laboratory.id, schedule.laboratory_id),
+            lte(schedule.start_time, now),
+            gte(schedule.end_time, now),
+          ),
+        )
+        .leftJoin(subjects, eq(schedule.subject_id, subjects.id))
+        .leftJoin(teachers, eq(schedule.teacher_id, teachers.id))
+        .orderBy(laboratory.name)
+
+      // Transform the data to include current status
+      const laboratoriesWithVacancy = laboratoriesWithSchedules.map((lab) => {
+        let vacancyStatus: 'available' | 'occupied' | 'maintenance'
+        let currentSchedule = null
+
+        // Determine current status
+        if (!lab.status) {
+          vacancyStatus = 'maintenance' // Laboratory is unavailable/under maintenance
+        }
+        else if (lab.scheduleId && lab.startTime && lab.endTime) {
+          vacancyStatus = 'occupied' // Laboratory has an active schedule
+          currentSchedule = {
+            id: lab.scheduleId,
+            section: lab.section || '',
+            start_time: lab.startTime.toISOString(),
+            end_time: lab.endTime.toISOString(),
+            subject_name: lab.subjectName || '',
+            teacher_name: `${lab.teacherFirstname || ''} ${lab.teacherLastname || ''}`.trim() || 'Unknown',
+          }
+        }
+        else {
+          vacancyStatus = 'available' // Laboratory is available
+        }
+
+        return {
+          id: lab.id,
+          name: lab.name,
+          status: lab.status,
+          vacancy_status: vacancyStatus,
+          current_schedule: currentSchedule,
+          created_at: lab.created_at.toISOString(),
+          updated_at: lab.updated_at.toISOString(),
+        }
+      })
+
+      this.logger.info('Laboratories with current status retrieved successfully', {
+        totalLaboratories: laboratoriesWithVacancy.length,
+        available: laboratoriesWithVacancy.filter(lab => lab.vacancy_status === 'available').length,
+        occupied: laboratoriesWithVacancy.filter(lab => lab.vacancy_status === 'occupied').length,
+        maintenance: laboratoriesWithVacancy.filter(lab => lab.vacancy_status === 'maintenance').length,
+        timestamp: new Date().toISOString(),
+      })
+
+      return laboratoriesWithVacancy
+    }
+    catch (error) {
+      this.logger.error('Failed to retrieve laboratories with current status', {
+        error: (error as Error).message,
+        timestamp: new Date().toISOString(),
+      })
+      throw error
+    }
+  }
 }

--- a/tests/handlers/teachers/get-teacher-laboratories.handler.spec.ts
+++ b/tests/handlers/teachers/get-teacher-laboratories.handler.spec.ts
@@ -1,0 +1,138 @@
+import type { Context } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GetTeacherLaboratoriesHandler } from '@/handlers/teachers/get-teacher-laboratories.handler'
+
+// Mock the TeacherService
+const mockGetLaboratoriesWithCurrentStatus = vi.fn()
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+vi.mock('@/services/TeacherService', () => ({
+  TeacherService: vi.fn().mockImplementation(() => ({
+    getLaboratoriesWithCurrentStatus: mockGetLaboratoriesWithCurrentStatus,
+  })),
+}))
+
+function createMockContext(): Context {
+  return {
+    var: {
+      logger: mockLogger,
+    },
+    json: vi.fn().mockImplementation((data, status) => ({
+      json: () => Promise.resolve(data),
+      status,
+    })),
+  } as unknown as Context
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getTeacherLaboratoriesHandler', () => {
+  it('should successfully retrieve laboratories and return 200 status', async () => {
+    const mockContext = createMockContext()
+    const mockLaboratories = [
+      {
+        id: 'lab001',
+        name: 'Computer Lab 1',
+        status: true,
+        scheduleId: 'sched001',
+        section: 'CS-3A',
+        startTime: new Date('2024-01-15T08:00:00Z'),
+        endTime: new Date('2024-01-15T10:00:00Z'),
+        subjectName: 'Data Structures',
+        teacherFirstname: 'John',
+        teacherLastname: 'Doe',
+      },
+      {
+        id: 'lab002',
+        name: 'Computer Lab 2',
+        status: true,
+        scheduleId: null,
+        section: null,
+        startTime: null,
+        endTime: null,
+        subjectName: null,
+        teacherFirstname: null,
+        teacherLastname: null,
+      },
+    ]
+
+    // Set up the mock to return the test data
+    mockGetLaboratoriesWithCurrentStatus.mockResolvedValue(mockLaboratories)
+
+    const handler = GetTeacherLaboratoriesHandler as unknown as (c: Context) => Promise<Response>
+    await handler(mockContext)
+
+    // Verify the TeacherService was called
+    expect(mockGetLaboratoriesWithCurrentStatus).toHaveBeenCalledOnce()
+
+    // Verify the response
+    expect(mockContext.json).toHaveBeenCalledWith(
+      {
+        message: 'Laboratories with current status retrieved successfully',
+        data: mockLaboratories,
+      },
+      200,
+    )
+  })
+
+  it('should handle errors and return 500 status', async () => {
+    const mockContext = createMockContext()
+    const errorMessage = 'Database connection failed'
+
+    // Mock the TeacherService method to throw an error
+    mockGetLaboratoriesWithCurrentStatus.mockRejectedValue(new Error(errorMessage))
+
+    const handler = GetTeacherLaboratoriesHandler as unknown as (c: Context) => Promise<Response>
+    await handler(mockContext)
+
+    // Verify the TeacherService was called
+    expect(mockGetLaboratoriesWithCurrentStatus).toHaveBeenCalledOnce()
+
+    // Verify the error response
+    expect(mockContext.json).toHaveBeenCalledWith(
+      {
+        message: 'Internal Server Error',
+        errors: errorMessage,
+      },
+      500,
+    )
+
+    // Verify error logger was called
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to retrieve laboratories',
+      {
+        error: errorMessage,
+        timestamp: expect.any(String),
+      },
+    )
+  })
+
+  it('should handle empty laboratories array', async () => {
+    const mockContext = createMockContext()
+    const emptyLaboratories: any[] = []
+
+    // Mock the TeacherService method
+    mockGetLaboratoriesWithCurrentStatus.mockResolvedValue(emptyLaboratories)
+
+    const handler = GetTeacherLaboratoriesHandler as unknown as (c: Context) => Promise<Response>
+    await handler(mockContext)
+
+    // Verify the TeacherService was called
+    expect(mockGetLaboratoriesWithCurrentStatus).toHaveBeenCalledOnce()
+
+    // Verify the response
+    expect(mockContext.json).toHaveBeenCalledWith(
+      {
+        message: 'Laboratories with current status retrieved successfully',
+        data: emptyLaboratories,
+      },
+      200,
+    )
+  })
+})

--- a/tests/services/TeacherService.spec.ts
+++ b/tests/services/TeacherService.spec.ts
@@ -1,0 +1,333 @@
+import type { Context } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TeacherService } from '@/services/TeacherService'
+
+const mockCreatedAt = new Date('2024-01-01T00:00:00Z')
+const mockUpdatedAt = new Date('2024-01-01T00:00:00Z')
+
+// Mock the database module
+vi.mock('@/db', () => ({
+  createDb: vi.fn(() => createMockDb()),
+}))
+
+// Mock database results
+const mockLaboratoriesWithSchedules = [
+  {
+    // Laboratory data
+    id: 'lab001',
+    name: 'Computer Lab 1',
+    status: true,
+    created_at: mockCreatedAt,
+    updated_at: mockUpdatedAt,
+    // Schedule data (occupied lab)
+    scheduleId: 'sched001',
+    section: 'CS-3A',
+    startTime: new Date('2024-01-15T08:00:00Z'),
+    endTime: new Date('2024-01-15T10:00:00Z'),
+    scheduleStatus: 'active',
+    subjectName: 'Data Structures',
+    teacherFirstname: 'John',
+    teacherLastname: 'Doe',
+  },
+  {
+    // Laboratory data
+    id: 'lab002',
+    name: 'Computer Lab 2',
+    status: true,
+    created_at: mockCreatedAt,
+    updated_at: mockUpdatedAt,
+    // No schedule data (available lab)
+    scheduleId: null,
+    section: null,
+    startTime: null,
+    endTime: null,
+    scheduleStatus: null,
+    subjectName: null,
+    teacherFirstname: null,
+    teacherLastname: null,
+  },
+  {
+    // Laboratory data
+    id: 'lab003',
+    name: 'Computer Lab 3',
+    status: false, // Under maintenance
+    created_at: mockCreatedAt,
+    updated_at: mockUpdatedAt,
+    // No schedule data
+    scheduleId: null,
+    section: null,
+    startTime: null,
+    endTime: null,
+    scheduleStatus: null,
+    subjectName: null,
+    teacherFirstname: null,
+    teacherLastname: null,
+  },
+]
+
+function createMockDb() {
+  let selectResults: any[] = []
+
+  const mockDb = {
+    // Set what select queries should return
+    setSelectResults: (results: any[]) => {
+      selectResults = results
+    },
+
+    // Mock select chain: db.select().from(table).leftJoin().leftJoin().leftJoin().orderBy()
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        leftJoin: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({
+            leftJoin: vi.fn(() => ({
+              where: vi.fn(() => ({
+                orderBy: vi.fn(async () => selectResults),
+              })),
+              orderBy: vi.fn(async () => selectResults),
+            })),
+          })),
+        })),
+      })),
+    })),
+
+    // Mock count chain: db.select().from(table).where()
+    count: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => [{ count: selectResults.length }]),
+      })),
+    })),
+  }
+
+  return mockDb
+}
+
+// Mock logger
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}
+
+function createFakeContext(): Context {
+  return {
+    env: { DATABASE_URL: 'postgres://test-url' },
+    var: {
+      logger: mockLogger,
+    },
+  } as unknown as Context
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('teacherService.getLaboratoriesWithCurrentStatus', () => {
+  it('should successfully retrieve laboratories with current status', async () => {
+    const mockContext = createFakeContext()
+    const mockDb = createMockDb()
+    mockDb.setSelectResults(mockLaboratoriesWithSchedules)
+    const teacherService = new TeacherService(mockContext)
+    // Mock the database instance
+    ;(teacherService as any).db = mockDb
+
+    const result = await teacherService.getLaboratoriesWithCurrentStatus()
+
+    expect(result).toHaveLength(3)
+
+    // Verify occupied laboratory
+    expect(result[0]).toEqual({
+      id: 'lab001',
+      name: 'Computer Lab 1',
+      status: true,
+      vacancy_status: 'occupied',
+      current_schedule: {
+        id: 'sched001',
+        section: 'CS-3A',
+        start_time: '2024-01-15T08:00:00.000Z',
+        end_time: '2024-01-15T10:00:00.000Z',
+        subject_name: 'Data Structures',
+        teacher_name: 'John Doe',
+      },
+      created_at: mockCreatedAt.toISOString(),
+      updated_at: mockUpdatedAt.toISOString(),
+    })
+
+    // Verify available laboratory
+    expect(result[1]).toEqual({
+      id: 'lab002',
+      name: 'Computer Lab 2',
+      status: true,
+      vacancy_status: 'available',
+      current_schedule: null,
+      created_at: mockCreatedAt.toISOString(),
+      updated_at: mockUpdatedAt.toISOString(),
+    })
+
+    // Verify maintenance laboratory
+    expect(result[2]).toEqual({
+      id: 'lab003',
+      name: 'Computer Lab 3',
+      status: false,
+      vacancy_status: 'maintenance',
+      current_schedule: null,
+      created_at: mockCreatedAt.toISOString(),
+      updated_at: mockUpdatedAt.toISOString(),
+    })
+
+    // Verify logger was called
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Laboratories with current status retrieved successfully',
+      {
+        totalLaboratories: 3,
+        available: 1,
+        occupied: 1,
+        maintenance: 1,
+        timestamp: expect.any(String),
+      },
+    )
+  })
+
+  it('should return empty array when no laboratories exist', async () => {
+    const mockContext = createFakeContext()
+    const mockDb = createMockDb()
+    mockDb.setSelectResults([])
+    const teacherService = new TeacherService(mockContext)
+    ;(teacherService as any).db = mockDb
+
+    const result = await teacherService.getLaboratoriesWithCurrentStatus()
+
+    expect(result).toEqual([])
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      'Laboratories with current status retrieved successfully',
+      {
+        totalLaboratories: 0,
+        available: 0,
+        occupied: 0,
+        maintenance: 0,
+        timestamp: expect.any(String),
+      },
+    )
+  })
+
+  it('should handle teacher name formatting correctly', async () => {
+    const mockContext = createFakeContext()
+    const mockDb = createMockDb()
+
+    const mockDataWithVariousNames = [
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        teacherFirstname: 'John',
+        teacherLastname: 'Doe',
+      },
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab004',
+        name: 'Lab 4',
+        teacherFirstname: 'Jane',
+        teacherLastname: null,
+      },
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab005',
+        name: 'Lab 5',
+        teacherFirstname: null,
+        teacherLastname: 'Smith',
+      },
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab006',
+        name: 'Lab 6',
+        teacherFirstname: null,
+        teacherLastname: null,
+      },
+    ]
+
+    mockDb.setSelectResults(mockDataWithVariousNames)
+    const teacherService = new TeacherService(mockContext)
+    ;(teacherService as any).db = mockDb
+
+    const result = await teacherService.getLaboratoriesWithCurrentStatus()
+
+    expect(result[0].current_schedule?.teacher_name).toBe('John Doe')
+    expect(result[1].current_schedule?.teacher_name).toBe('Jane')
+    expect(result[2].current_schedule?.teacher_name).toBe('Smith')
+    expect(result[3].current_schedule?.teacher_name).toBe('Unknown')
+  })
+
+  it('should handle database errors', async () => {
+    const mockContext = createFakeContext()
+    // Mock database error by making the orderBy method reject
+    const mockDb = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          leftJoin: vi.fn(() => ({
+            leftJoin: vi.fn(() => ({
+              leftJoin: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  orderBy: vi.fn().mockRejectedValue(new Error('Database connection failed')),
+                })),
+                orderBy: vi.fn().mockRejectedValue(new Error('Database connection failed')),
+              })),
+            })),
+          })),
+        })),
+      })),
+    }
+    const teacherService = new TeacherService(mockContext)
+    ;(teacherService as any).db = mockDb
+
+    await expect(teacherService.getLaboratoriesWithCurrentStatus()).rejects.toThrow(
+      'Database connection failed',
+    )
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Failed to retrieve laboratories with current status',
+      {
+        error: 'Database connection failed',
+        timestamp: expect.any(String),
+      },
+    )
+  })
+
+  it('should correctly determine vacancy status based on conditions', async () => {
+    const mockContext = createFakeContext()
+    const mockDb = createMockDb()
+
+    const testCases = [
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab_available',
+        name: 'Available Lab',
+        status: true,
+        scheduleId: null,
+        expectedStatus: 'available',
+      },
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab_occupied',
+        name: 'Occupied Lab',
+        status: true,
+        scheduleId: 'sched001',
+        expectedStatus: 'occupied',
+      },
+      {
+        ...mockLaboratoriesWithSchedules[0],
+        id: 'lab_maintenance',
+        name: 'Maintenance Lab',
+        status: false,
+        scheduleId: null,
+        expectedStatus: 'maintenance',
+      },
+    ]
+
+    mockDb.setSelectResults(testCases)
+    const teacherService = new TeacherService(mockContext)
+    ;(teacherService as any).db = mockDb
+
+    const result = await teacherService.getLaboratoriesWithCurrentStatus()
+
+    expect(result[0].vacancy_status).toBe('available')
+    expect(result[1].vacancy_status).toBe('occupied')
+    expect(result[2].vacancy_status).toBe('maintenance')
+  })
+})


### PR DESCRIPTION
- Added new endpoint that retrieves laboratories with current status. Main use is that this serves a specific teacher-focused use case to see all laboratory status with additional information to determine vacancy and unavailable laboratories
- RBAC implementation (teacher/admin access only)

- GET /teachers/laboratories
<img width="1919" height="1079" alt="Screenshot 2025-09-14 232455" src="https://github.com/user-attachments/assets/8fad6b8e-75d4-4c50-8d55-50638a2f2e8b" />

- {
  "message": "Laboratories retrieved successfully",
  "data": [
    {
      "id": "lab001",
      "name": "Computer Laboratory 1",
      "status": true,
      "vacancy_status": "occupied",
      "current_schedule": {
        "id": "sched001",
        "section": "A",
        "start_time": "2025-09-14T12:48:15.453Z",
        "end_time": "2025-09-14T14:48:15.453Z",
        "subject_name": "Introduction to Programming",
        "teacher_name": "John Doe"
      },
      "created_at": "2025-09-14T13:15:14.224Z",
      "updated_at": "2025-09-14T13:15:14.224Z"
    },
    {
      "id": "lab002",
      "name": "Computer Laboratory 2",
      "status": true,
      "vacancy_status": "occupied",
      "current_schedule": {
        "id": "sched002",
        "section": "B",
        "start_time": "2025-09-14T13:18:15.453Z",
        "end_time": "2025-09-14T15:18:15.453Z",
        "subject_name": "Data Structures and Algorithms",
        "teacher_name": "Jane Smith"
      },
      "created_at": "2025-09-14T13:15:14.224Z",
      "updated_at": "2025-09-14T13:15:14.224Z"
    },
    {
      "id": "lab003",
      "name": "Computer Laboratory 3",
      "status": false,
      "vacancy_status": "maintenance",
      "current_schedule": null,
      "created_at": "2025-09-14T13:15:14.224Z",
      "updated_at": "2025-09-14T13:15:14.224Z"
    }
  ]
}

- Auth and RBAC
<img width="1919" height="1079" alt="Screenshot 2025-09-14 232538" src="https://github.com/user-attachments/assets/78507bd5-a832-4229-b1bd-ad73b324d91d" />

- Tests (Handler)
<img width="503" height="138" alt="image" src="https://github.com/user-attachments/assets/079ac87c-c648-48bc-b19a-8aa0f4470eb0" />

- Tests (Service)
<img width="501" height="163" alt="image" src="https://github.com/user-attachments/assets/2cf976f4-acf7-4b7d-b2e6-141ff7fa5bc1" />


