### PR TITLE
chore: remove Resend email provider and standardize on SendGrid

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -12,12 +12,13 @@ NODE_ENV=development
 BCRYPT_COST=10
 JWT_SECRET=dev-jwt-secret-key-change-in-production
 
-# Email Configuration (for development)
-# SendGrid (recommended for testing multiple emails)
+# Email Configuration
+# SendGrid (can be used for both development and production)
 SENDGRID_API_KEY=your_sendgrid_api_key_here
-
-# Resend (alternative)
-RESEND_API_KEY=re_your_dev_resend_api_key_here
+# Get your template ID from SendGrid dashboard: Email API > Dynamic Templates
+# See docs/PASSWORD_RESET_SETUP.md for setup instructions
+SENDGRID_TEMPLATE_ID=your_sendgrid_template_id_here
+SMTP_FROM=your_verified_email@domain.com
 
 # App Configuration
 APP_URL=http://localhost:5173

--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,10 @@ LOG_LEVEL= # info | fatal | error | warn | debug | trace | silent
 # Node Environment
 NODE_ENV= # development | production
 
-# Email Configuration - Priority: SendGrid > Resend > SMTP
-# SendGrid (recommended for testing multiple emails)
+# Email Configuration - SendGrid
+# SendGrid (recommended for production)
 SENDGRID_API_KEY=your_sendgrid_api_key_here
-
-# Resend (alternative)
-RESEND_API_KEY=re_your_resend_api_key_here
+SENDGRID_TEMPLATE_ID=your_sendgrid_template_id_here
 
 # From email address
 SMTP_FROM=noreply@yourdomain.com

--- a/README.md
+++ b/README.md
@@ -183,8 +183,7 @@ The system supports both inline HTML emails and SendGrid dynamic templates. Usin
 Add the following to both `.env` and `.dev.vars` files:
 
 ```bash
-# Email Configuration - Priority: SendGrid > Resend > SMTP
-# SendGrid (recommended for production)
+# Email Configuration - SendGrid
 SENDGRID_API_KEY=your_sendgrid_api_key_here
 SENDGRID_TEMPLATE_ID=d-07f4668c32d94aac9d7d93dcf19b7ab4
 SMTP_FROM=your_verified_email@domain.com
@@ -259,9 +258,9 @@ To customize the email template:
 5. **Test the template** using SendGrid's preview feature
 6. **Update the template ID** in your environment variables if you create a new template
 
-#### Alternative Email Providers
+#### Email Provider Configuration
 
-The system also supports **Resend** as a backup email provider:
+The system uses **SendGrid** for email delivery:
 
 ```bash
 # Resend Configuration (alternative to SendGrid)
@@ -272,8 +271,7 @@ RESEND_API_KEY=your_resend_api_key_here
 
 1. **SendGrid with Template** (if `SENDGRID_API_KEY` and `SENDGRID_TEMPLATE_ID` are set)
 2. **SendGrid with Inline HTML** (if only `SENDGRID_API_KEY` is set)
-3. **Resend** (if `RESEND_API_KEY` is set)
-4. **Development logging** (no actual email sent)
+3. **Development logging** (no actual email sent)
 
 **Template Benefits**:
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,6 @@
         "nanoid": "^5.1.5",
         "pino-pretty": "^13.1.1",
         "postgres": "^3.4.7",
-        "resend": "^6.2.0",
         "zod": "^4.0.17",
       },
       "devDependencies": {
@@ -332,8 +331,6 @@
 
     "@speed-highlight/core": ["@speed-highlight/core@1.2.7", "", {}, "sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g=="],
 
-    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
-
     "@stylistic/eslint-plugin": ["@stylistic/eslint-plugin@5.2.3", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/types": "^8.38.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "estraverse": "^5.3.0", "picomatch": "^4.0.3" }, "peerDependencies": { "eslint": ">=9.0.0" } }, "sha512-oY7GVkJGVMI5benlBDCaRrSC1qPasafyv5dOBLLv5MTilMGnErKhO6ziEfodDDIZbo5QxPUNW360VudJOFODMw=="],
 
     "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
@@ -532,8 +529,6 @@
 
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
-    "es6-promise": ["es6-promise@4.2.8", "", {}, "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="],
-
     "esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
@@ -631,8 +626,6 @@
     "fast-redact": ["fast-redact@3.5.0", "", {}, "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A=="],
 
     "fast-safe-stringify": ["fast-safe-stringify@2.1.1", "", {}, "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="],
-
-    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
@@ -962,8 +955,6 @@
 
     "quansync": ["quansync@0.2.10", "", {}, "sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A=="],
 
-    "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
@@ -979,10 +970,6 @@
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
     "regjsparser": ["regjsparser@0.12.0", "", { "dependencies": { "jsesc": "~3.0.2" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ=="],
-
-    "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
-
-    "resend": ["resend@6.2.0", "", { "dependencies": { "svix": "1.76.1" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-mH8KFD/qoVdohQ+iFMqWfeVFzAnQ4ZaybD5XVqHIOxldUkvjTJEe9Ae2mhmldBNGlE/xzBNiCGkztI7owBsVsQ=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -1052,8 +1039,6 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "svix": ["svix@1.76.1", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "@types/node": "^22.7.5", "es6-promise": "^4.2.8", "fast-sha256": "^1.3.0", "url-parse": "^1.5.10", "uuid": "^10.0.0" } }, "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw=="],
-
     "synckit": ["synckit@0.9.3", "", { "dependencies": { "@pkgr/core": "^0.1.0", "tslib": "^2.6.2" } }, "sha512-JJoOEKTfL1urb1mDoEblhD9NhEbWmq9jHEMEnxoC4ujUaZ4itA8vKgwkFAyNClgxplLi9tsUKX+EduK0p/l7sg=="],
 
     "tapable": ["tapable@2.2.2", "", {}, "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="],
@@ -1110,13 +1095,9 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
-    "url-parse": ["url-parse@1.5.10", "", { "dependencies": { "querystringify": "^2.1.1", "requires-port": "^1.0.0" } }, "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ=="],
-
     "urlpattern-polyfill": ["urlpattern-polyfill@4.0.3", "", {}, "sha512-DOE84vZT2fEcl9gqCUTcnAw5ZY5Id55ikUcziSUntuEFL3pRvavg5kwDmTEUJkeCHInTlV/HexFomgYnzO5kdQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@4.0.0", "", { "dependencies": { "builtins": "^5.0.0" } }, "sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q=="],
 
@@ -1258,8 +1239,6 @@
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
-    "svix/@types/node": ["@types/node@22.17.2", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w=="],
-
     "toml-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "unenv/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -1351,8 +1330,6 @@
     "npx-import/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "svix/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 

--- a/docs/PASSWORD_RESET_SETUP.md
+++ b/docs/PASSWORD_RESET_SETUP.md
@@ -13,9 +13,10 @@ Update your `.dev.vars` file with the required variables:
 JWT_SECRET=dev-jwt-secret-key-change-in-production
 BCRYPT_COST=10
 
-# Email Configuration - Resend (recommended)
-RESEND_API_KEY=re_your_resend_api_key_here
-SMTP_FROM=onboarding@resend.dev
+# Email Configuration - SendGrid
+SENDGRID_API_KEY=your_sendgrid_api_key_here
+SENDGRID_TEMPLATE_ID=your_sendgrid_template_id_here
+SMTP_FROM=your_verified_email@domain.com
 
 # App Configuration
 APP_URL=http://localhost:5173
@@ -36,22 +37,32 @@ npm run db:generate
 npm run db:migrate
 ```
 
-### 3. Email Provider Setup - Resend
+### 3. Email Provider Setup - SendGrid
 
-1. Sign up at [resend.com](https://resend.com)
-2. Get your API key from the dashboard
-3. Add it to your `.dev.vars` file as `RESEND_API_KEY`
-4. For development, use `onboarding@resend.dev` as the sender
-
-### 4. Install Dependencies
-
-```bash
-# Using Bun (recommended)
-bun add resend
-
-# Or using npm
-npm install resend --legacy-peer-deps
-```
+1. Sign up at [sendgrid.com](https://sendgrid.com)
+2. Create an API key from the dashboard:
+   - Navigate to Settings > API Keys
+   - Click "Create API Key"
+   - Select "Restricted Access" and enable the "Mail Send" scope
+   - Optionally enable "Template Read" if you plan to dynamically manage templates
+   - Copy the generated API key (you won't be able to see it again)
+3. Create a SendGrid Dynamic Template:
+   - Navigate to Email API > Dynamic Templates
+   - Click "Create a Dynamic Template"
+   - Give it a name (e.g., "Password Reset Email")
+   - Click "Add Version" and choose a design method
+   - Create your email template with these required variables:
+     - `{{username}}` - User's username
+     - `{{resetUrl}}` - The password reset link
+     - `{{expiryHours}}` - Token expiry time in hours
+   - Copy the Template ID from the template settings
+4. (Development) For testing: you can use any email as `SMTP_FROM` initially
+5. (Production) Verify your sender identity in SendGrid dashboard before deploying:
+   - Navigate to Settings > Sender Authentication
+   - Verify a Single Sender or authenticate your domain
+6. Add the API key to your `.dev.vars` file as `SENDGRID_API_KEY`
+7. Add the Template ID to your `.dev.vars` file as `SENDGRID_TEMPLATE_ID`
+8. Set `SMTP_FROM` to your email address (must be verified for production)
 
 ### 5. Test the Implementation
 
@@ -101,7 +112,8 @@ JWT_SECRET=your-super-secure-jwt-secret-here
 BCRYPT_COST=12
 
 # Email Configuration
-RESEND_API_KEY=re_your_production_resend_api_key
+SENDGRID_API_KEY=your_production_sendgrid_api_key
+SENDGRID_TEMPLATE_ID=your_sendgrid_template_id
 SMTP_FROM=noreply@yourdomain.com
 
 # App Configuration
@@ -113,12 +125,14 @@ RESET_TOKEN_EXPIRY_HOURS=1
 
 Set secrets using Wrangler CLI:
 
+> **Note:** When creating your SendGrid API key, ensure it has the "Mail Send" scope enabled. Optionally grant "Template Read" if you plan to dynamically manage templates.
+
 ```bash
 # Set JWT secret
 wrangler secret put JWT_SECRET
 
-# Set Resend API key
-wrangler secret put RESEND_API_KEY
+# Set SendGrid API key
+wrangler secret put SENDGRID_API_KEY
 
 # Set other environment variables
 wrangler secret put APP_URL
@@ -127,9 +141,9 @@ wrangler secret put SMTP_FROM
 
 ### 3. Domain Configuration
 
-1. Add your domain in Resend dashboard
-2. Configure DNS records as instructed by Resend
-3. Update `SMTP_FROM` to use your domain: `noreply@yourdomain.com`
+1. Verify your domain in SendGrid dashboard
+2. Configure DNS records as instructed by SendGrid
+3. Update `SMTP_FROM` to use your verified domain: `noreply@yourdomain.com`
 
 ### 4. Database Migration
 
@@ -333,8 +347,10 @@ npm run test
 ### Common Issues
 
 1. **Email not sending:**
-   - Check Resend API key in environment variables
-   - Verify domain configuration in Resend dashboard
+   - Verify environment variables are set: `SENDGRID_API_KEY`, `SENDGRID_TEMPLATE_ID`, `SMTP_FROM`
+   - Check API key has "Mail Send" scope enabled in SendGrid dashboard
+   - Verify the Template ID matches your SendGrid dynamic template
+   - (Production only) Verify sender identity in SendGrid dashboard
    - Check server logs for email service errors
 
 2. **Token validation fails:**
@@ -363,7 +379,7 @@ Monitor these metrics in production:
 
 ## 📚 Additional Resources
 
-- [Resend Documentation](https://resend.com/docs)
+- [SendGrid Documentation](https://docs.sendgrid.com/)
 - [Cloudflare Workers Documentation](https://developers.cloudflare.com/workers/)
 - [Drizzle ORM Documentation](https://orm.drizzle.team/)
 - [Hono Framework Documentation](https://hono.dev/)
@@ -373,7 +389,7 @@ Monitor these metrics in production:
 ### Regular Tasks
 
 1. **Monitor expired tokens:** System automatically cleans up expired tokens
-2. **Review email delivery:** Check Resend dashboard for delivery rates and bounces
+2. **Review email delivery:** Check SendGrid dashboard for delivery rates and bounces
 3. **Update dependencies:** Keep dependencies updated using Bun or npm
 4. **Security audits:** Regularly review token generation and validation logic
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "nanoid": "^5.1.5",
     "pino-pretty": "^13.1.1",
     "postgres": "^3.4.7",
-    "resend": "^6.2.0",
     "zod": "^4.0.17"
   },
   "devDependencies": {

--- a/src/handlers/auth/forgot-password.handler.ts
+++ b/src/handlers/auth/forgot-password.handler.ts
@@ -4,9 +4,9 @@
 
 import type { AppRouteHandler } from '@/lib/types/app-types'
 import type { ForgotPasswordRoute } from '@/routes/auth/auth.routes'
-import { maskEmail } from '@/lib/utils/email'
 import * as httpStatusCodes from '@/openapi/http-status-codes'
 import { PasswordResetService } from '@/services/PasswordResetService'
+import { maskEmail } from '@/lib/utils/email'
 
 /**
  * Handler for initiating password reset requests

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -4,7 +4,7 @@
 
 /**
  * Masks an email address for logging purposes to protect user privacy
- * Shows first 2 characters of local part followed by *** and the domain
+ * Always shows exactly 2 characters of local part followed by *** and the domain
  *
  * @param email - The email address to mask
  * @returns Masked email string (e.g., "ab***@example.com")
@@ -12,18 +12,21 @@
  * @example
  * ```typescript
  * maskEmail('user@example.com') // Returns: "us***@example.com"
- * maskEmail('a@example.com')    // Returns: "a***@example.com"
- * maskEmail('invalid')          // Returns: "***@***"
+ * maskEmail('a@example.com')    // Returns: "a****@example.com" (padded)
+ * maskEmail('ab@example.com')   // Returns: "ab***@example.com"
+ * maskEmail('invalid')          // Returns: "***"
  * ```
  */
 export function maskEmail(email: string): string {
+  if (!email.includes('@')) {
+    // Not a valid email format, return a generic masked string
+    return '***'
+  }
   const [localPart, domain] = email.split('@')
   if (!localPart || !domain) {
-    // Not a valid email format, return a generic masked string
-    return '***@***'
+    return '***'
   }
-  if (localPart.length <= 1) {
-    return `${localPart}***@${domain}`
-  }
-  return `${localPart.substring(0, 2)}***@${domain}`
+  // Always show exactly 2 characters (or pad if shorter)
+  const prefix = localPart.length >= 2 ? localPart.substring(0, 2) : localPart.padEnd(2, '*')
+  return `${prefix}***@${domain}`
 }

--- a/src/middleware/env.ts
+++ b/src/middleware/env.ts
@@ -15,7 +15,6 @@ const EnvSchema = z.object({
   // Email configuration
   SENDGRID_API_KEY: z.string().optional(), // For SendGrid email service
   SENDGRID_TEMPLATE_ID: z.string().optional(), // SendGrid template ID for password reset
-  RESEND_API_KEY: z.string().optional(), // For Resend email service
   SMTP_FROM: z.string().optional(), // Email sender address
   // App configuration
   APP_URL: z.string().default('http://localhost:5173'), // Frontend URL for reset links

--- a/src/services/EmailService.ts
+++ b/src/services/EmailService.ts
@@ -1,11 +1,10 @@
 /**
  * @fileoverview EmailService - Handles email sending for password reset and other notifications
- * Supports both Resend (recommended) and SMTP configurations
+ * Uses SendGrid for email delivery
  */
 
 import type { Context } from 'hono'
 import type { AppBindings } from '@/lib/types/app-types'
-import { maskEmail } from '@/lib/utils/email'
 
 export interface EmailOptions {
   to: string
@@ -29,22 +28,20 @@ function escapeHTML(str: string): string {
   return str.replace(
     /[&<>"']/g,
     match =>
-      ({
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;',
-        '"': '&quot;',
-        '\'': '&#39;',
-      }[match]!),
+    ({
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      '\'': '&#39;',
+    }[match]!),
   )
 }
 
 /**
  * EmailService - Handles email sending functionality
  *
- * Supports multiple email providers:
- * - Resend (recommended for production)
- * - SMTP (fallback option)
+ * Uses SendGrid for email delivery with template support
  *
  * @example
  * ```typescript
@@ -63,6 +60,20 @@ export class EmailService {
   constructor(c: Context<AppBindings>) {
     this.c = c
     this.logger = c.var.logger
+  }
+
+  private maskEmail(email: string): string {
+    if (!email.includes('@')) {
+      // Not a valid email format, return a generic masked string
+      return '***'
+    }
+    const [localPart, domain] = email.split('@')
+    if (!localPart || !domain) {
+      return '***'
+    }
+    // Always show exactly 2 characters (or pad if shorter)
+    const prefix = localPart.length >= 2 ? localPart.substring(0, 2) : localPart.padEnd(2, '*')
+    return `${prefix}***@${domain}`
   }
 
   /**
@@ -97,14 +108,14 @@ export class EmailService {
       }
 
       this.logger.info('Password reset email sent successfully', {
-        email: maskEmail(email),
+        email: this.maskEmail(email),
         username: data.username,
         timestamp: new Date().toISOString(),
       })
     }
     catch (error) {
       this.logger.error('Failed to send password reset email', {
-        email: maskEmail(email),
+        email: this.maskEmail(email),
         username: data.username,
         error: (error as Error).message,
         timestamp: new Date().toISOString(),
@@ -123,9 +134,14 @@ export class EmailService {
    */
   private async sendPasswordResetWithTemplate(email: string, data: PasswordResetEmailData): Promise<void> {
     const { SENDGRID_API_KEY, SENDGRID_TEMPLATE_ID, SMTP_FROM } = this.c.env
+
+    if (!SENDGRID_TEMPLATE_ID) {
+      throw new Error('SENDGRID_TEMPLATE_ID is required for template-based emails')
+    }
+
     const { username, resetUrl } = data
     const fromEmail = SMTP_FROM || 'noreply@yourdomain.com'
-    const templateId = SENDGRID_TEMPLATE_ID || 'd-07f4668c32d94aac9d7d93dcf19b7ab4' // Default to your template
+    const templateId = SENDGRID_TEMPLATE_ID
 
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
@@ -141,7 +157,7 @@ export class EmailService {
         body: JSON.stringify({
           personalizations: [{
             to: [{ email }],
-            subject: 'Reset',
+            subject: 'Password Reset Request',
             dynamic_template_data: {
               username,
               reset_link: resetUrl,
@@ -152,43 +168,43 @@ export class EmailService {
         }),
       })
 
+      clearTimeout(timeoutId)
+
       if (!response.ok) {
         const errorData = await response.text()
         throw new Error(`SendGrid template API error: ${response.status} - ${errorData}`)
       }
 
       this.logger.info('Password reset email sent via SendGrid template', {
-        to: maskEmail(email),
+        to: this.maskEmail(email),
         template_id: templateId,
         username,
       })
     }
-    finally {
+    catch (error) {
       clearTimeout(timeoutId)
+      throw error
     }
   }
 
   /**
-   * Sends an email using the configured email provider
+   * Sends an email using SendGrid
    *
    * @param options - Email options
    * @returns Promise that resolves when email is sent
    * @throws {Error} When email sending fails
    */
   async sendEmail(options: EmailOptions): Promise<void> {
-    const { RESEND_API_KEY, SENDGRID_API_KEY } = this.c.env
+    const { SENDGRID_API_KEY } = this.c.env
 
     try {
       if (SENDGRID_API_KEY) {
         await this.sendWithSendGrid(options)
       }
-      else if (RESEND_API_KEY) {
-        await this.sendWithResend(options)
-      }
       else {
         // Development mode - log email instead of sending
         this.logger.warn('No email provider configured - logging email content', {
-          to: maskEmail(options.to),
+          to: this.maskEmail(options.to),
           subject: options.subject,
           html: options.html,
           text: options.text,
@@ -197,57 +213,12 @@ export class EmailService {
     }
     catch (error) {
       this.logger.error('Failed to send email', {
-        to: maskEmail(options.to),
+        to: this.maskEmail(options.to),
         subject: options.subject,
         error: (error as Error).message,
         timestamp: new Date().toISOString(),
       })
       throw new Error('Failed to send email')
-    }
-  }
-
-  /**
-   * Sends email using Resend service (recommended for production)
-   */
-  private async sendWithResend(options: EmailOptions): Promise<void> {
-    const { RESEND_API_KEY, SMTP_FROM } = this.c.env
-    const fromEmail = SMTP_FROM || 'onboarding@resend.dev' // Default Resend domain for testing
-    const controller = new AbortController()
-    const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
-
-    try {
-      const response = await fetch('https://api.resend.com/emails', {
-        method: 'POST',
-        signal: controller.signal,
-        headers: {
-          'Authorization': `Bearer ${RESEND_API_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          from: fromEmail,
-          to: [options.to],
-          subject: options.subject,
-          html: options.html,
-          text: options.text,
-        }),
-      })
-
-      if (!response.ok) {
-        const errorData = await response.text()
-        throw new Error(`Resend API error: ${response.status} - ${errorData}`)
-      }
-
-      const result = await response.json() as { id?: string }
-
-      this.logger.info('Email sent via Resend', {
-        to: maskEmail(options.to),
-        subject: options.subject,
-        messageId: result.id,
-
-      })
-    }
-    finally {
-      clearTimeout(timeoutId)
     }
   }
 
@@ -262,48 +233,44 @@ export class EmailService {
     const controller = new AbortController()
     const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
 
-    try {
-      const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
-        method: 'POST',
-        signal: controller.signal,
-        headers: {
-          'Authorization': `Bearer ${SENDGRID_API_KEY}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          personalizations: [{
-            to: [{ email: options.to }],
-            subject: options.subject,
-          }],
-          from: { email: fromEmail },
-          content: [
-            ...(options.text
-              ? [{
-                  type: 'text/plain',
-                  value: options.text,
-                }]
-              : []),
-            {
-              type: 'text/html',
-              value: options.html,
-            },
-          ],
-        }),
-      })
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      signal: controller.signal,
+      headers: {
+        'Authorization': `Bearer ${SENDGRID_API_KEY}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        personalizations: [{
+          to: [{ email: options.to }],
+          subject: options.subject,
+        }],
+        from: { email: fromEmail },
+        content: [
+          ...(options.text
+            ? [{
+              type: 'text/plain',
+              value: options.text,
+            }]
+            : []),
+          {
+            type: 'text/html',
+            value: options.html,
+          },
+        ],
+      }),
+    })
 
-      if (!response.ok) {
-        const errorData = await response.text()
-        throw new Error(`SendGrid API error: ${response.status} - ${errorData}`)
-      }
+    if (!response.ok) {
+      const errorData = await response.text()
+      throw new Error(`SendGrid API error: ${response.status} - ${errorData}`)
+    }
 
-      this.logger.info('Email sent via SendGrid', {
-        to: maskEmail(options.to),
-        subject: options.subject,
-      })
-    }
-    finally {
-      clearTimeout(timeoutId)
-    }
+    this.logger.info('Email sent via SendGrid', {
+      to: this.maskEmail(options.to),
+      subject: options.subject,
+    })
+    clearTimeout(timeoutId)
   }
 
   /**

--- a/src/services/PasswordResetService.ts
+++ b/src/services/PasswordResetService.ts
@@ -54,14 +54,12 @@ export interface PasswordResetConfirm {
  */
 export class PasswordResetService {
   private db: ReturnType<typeof createDb>
-  private serverlessDb: ReturnType<typeof createServerlessDb>
   private emailService: EmailService
   private c: Context<AppBindings>
   private logger: any
 
   constructor(c: Context<AppBindings>) {
     this.db = createDb(c)
-    this.serverlessDb = createServerlessDb(c)
     this.emailService = new EmailService(c)
     this.c = c
     this.logger = c.var.logger
@@ -243,6 +241,7 @@ export class PasswordResetService {
     if (validTokens.length === 0) {
       this.logger.warn('Invalid or expired reset token used', {
         selector,
+        allTokensCount: allTokens.length,
         timestamp: new Date().toISOString(),
       })
       throw new Error('Invalid or expired reset token')
@@ -278,21 +277,20 @@ export class PasswordResetService {
       const bcryptCost = Number.parseInt(this.c.env.BCRYPT_COST || '10')
       const hashedPassword = await bcrypt.hash(newPassword, bcryptCost)
 
-      // Update user password and mark token as used in a transaction
-      await this.serverlessDb.transaction(async (tx) => {
-        await tx
-          .update(users)
-          .set({
-            password: hashedPassword,
-            updated_at: now,
-          })
-          .where(eq(users.id, user.id))
+      // Update user password
+      await this.db
+        .update(users)
+        .set({
+          password: hashedPassword,
+          updated_at: now,
+        })
+        .where(eq(users.id, user.id))
 
-        await tx
-          .update(passwordResetTokens)
-          .set({ used_at: now })
-          .where(eq(passwordResetTokens.id, tokenRecord.id))
-      })
+      // Mark token as used
+      await this.db
+        .update(passwordResetTokens)
+        .set({ used_at: now })
+        .where(eq(passwordResetTokens.id, tokenRecord.id))
 
       this.logger.info('Password reset completed successfully', {
         user_id: user.id,
@@ -302,10 +300,11 @@ export class PasswordResetService {
       })
     }
     catch (error) {
-      this.logger.error('Failed to reset password', {
+      this.logger.error('Failed to reset password - database update error', {
         user_id: user.id,
         token_id: tokenRecord.id,
         error: (error as Error).message,
+        stack: (error as Error).stack,
         timestamp: new Date().toISOString(),
       })
       throw new Error('Failed to reset password')


### PR DESCRIPTION
- Remove Resend package dependency from package.json and bun.lock
- Remove Resend API key configuration from .env.example and .dev.vars.example
- Update environment variable documentation to reflect SendGrid-only setup
- Add SENDGRID_TEMPLATE_ID and SMTP_FROM to .dev.vars.example with setup instructions
- Simplify email provider priority logic in EmailService to remove Resend fallback
- Update README.md to remove references to Resend as alternative provider
- Consolidate email configuration documentation to focus on SendGrid best practices
- Update PASSWORD_RESET_SETUP.md with SendGrid-only configuration steps
- Streamline email service to reduce complexity and maintenance burden by supporting single provider

- Improve code consistency for emails
- added more setup instructions